### PR TITLE
Add support to a default admin user

### DIFF
--- a/resources/config.example.edn
+++ b/resources/config.example.edn
@@ -5,7 +5,10 @@
         :password-reset-expiration-days 1
         :topics                         ["porteiro.create-contact"]
         :service                        {:host "0.0.0.0"
-                                         :port 8010}}
+                                         :port 8010}
+        :admin-user-seed                {:username "admin"
+                                         :password "very-strong-password"
+                                         :email    "brunodonascimento@gmail.com"}}
  :test {:jwt-secret                     "9837ed52-87b5-48c4-bd09-1cd06d18c1c5"
         :datomic-uri                    "datomic:mem://example"
         :bootstrap-server               "http://localhost:9092"
@@ -13,4 +16,7 @@
         :password-reset-expiration-days 1
         :topics                         ["porteiro.create-contact"]
         :service                        {:host "0.0.0.0"
-                                         :port 8010}}}
+                                         :port 8010}
+        :admin-user-seed                {:username "admin"
+                                         :password "very-strong-password"
+                                         :email    "brunodonascimento@gmail.com"}}}

--- a/src/porteiro/admin.clj
+++ b/src/porteiro/admin.clj
@@ -1,0 +1,27 @@
+(ns porteiro.admin
+  (:require [com.stuartsierra.component :as component]
+            [porteiro.diplomatic.http-server.user :as diplomatic.http-server.user]
+            [medley.core :as medley]
+            [taoensso.timbre :as timbre]
+            [porteiro.db.datomic.user :as database.user]))
+
+(defrecord Admin [config datomic]
+  component/Lifecycle
+  (start [component]
+    (let [{{:keys [admin-user-seed] :as config-content} :config} config
+          components (medley/assoc-some {}
+                                        :datomic (:datomic datomic)
+                                        :config config-content)]
+
+      (when-not (database.user/by-username (:username admin-user-seed) (-> components :datomic :connection))
+        (let [wire-user-id (-> (diplomatic.http-server.user/create-user! {:json-params (timbre/spy admin-user-seed)
+                                                                          :components  components})
+                               :body :user :id)]
+          (diplomatic.http-server.user/add-role! {:query-params {:user-id wire-user-id
+                                                                 :role    "ADMIN"}
+                                                  :components   components})))))
+
+  (stop [component]))
+
+(defn new-admin []
+  (->Admin {} {}))

--- a/src/porteiro/components.clj
+++ b/src/porteiro/components.clj
@@ -6,6 +6,7 @@
             [common-clj.component.kafka.consumer :as component.consumer]
             [common-clj.component.service :as component.service]
             [common-clj.component.routes :as component.routes]
+            [porteiro.admin :as admin]
             [porteiro.diplomatic.http-server :as diplomatic.http-server]
             [porteiro.diplomatic.consumer :as diplomatic.consumer]
             [porteiro.db.datomic.config :as database.config]))
@@ -17,6 +18,7 @@
     :consumer (component/using (component.consumer/new-consumer diplomatic.consumer/topic-consumers) [:config :datomic])
     :producer (component/using (component.producer/new-producer) [:config])
     :routes (component/using (component.routes/new-routes diplomatic.http-server/routes) [:datomic :config])
+    :admin (component/using (admin/new-admin) [:datomic :config])
     :service (component/using (component.service/new-service) [:routes :config :datomic :producer])))
 
 (defn start-system! []
@@ -29,4 +31,5 @@
     :consumer (component/using (component.consumer/new-mock-consumer diplomatic.consumer/topic-consumers) [:config :datomic])
     :producer (component/using (component.producer/new-mock-producer) [:consumer :config])
     :routes (component/using (component.routes/new-routes diplomatic.http-server/routes) [:datomic :config])
+    :admin (component/using (admin/new-admin) [:datomic :config])
     :service (component/using (component.service/new-service) [:routes :config :datomic :producer])))

--- a/src/porteiro/db/datomic/user.clj
+++ b/src/porteiro/db/datomic/user.clj
@@ -27,10 +27,11 @@
 (s/defn by-username :- (s/maybe models.user/User)
   [username :- s/Str
    datomic]
-  (-> (d/q '[:find (pull ?user [:user/id :user/username :user/email :user/hashed-password])
-             :in $ ?username
-             :where [?user :user/username ?username]] (d/db datomic) username)
-      ffirst))
+  (some-> (d/q '[:find (pull ?user [*])
+                 :in $ ?username
+                 :where [?user :user/username ?username]] (d/db datomic) username)
+          ffirst
+          (dissoc :db/id)))
 
 (s/defn by-email :- (s/maybe models.user/User)
   [email :- s/Str

--- a/src/porteiro/diplomatic/http_server/user.clj
+++ b/src/porteiro/diplomatic/http_server/user.clj
@@ -17,8 +17,8 @@
 
 (s/defn add-role!
   [{{wire-user-id :user-id
-     wire-role    :role}       :query-params
-    {:keys [datomic producer]} :components}]
+     wire-role    :role} :query-params
+    {:keys [datomic]}    :components}]
   {:status 200
    :body   (-> (controllers.user/add-role! (UUID/fromString wire-user-id)
                                            (adapters.user/wire->internal-role wire-role)

--- a/test/helpers/fixtures/user.clj
+++ b/test/helpers/fixtures/user.clj
@@ -11,9 +11,9 @@
            :email    "example@example.com"
            :password "some-strong-password"})
 
-(def admin-user {:username "admin"
-                 :email    "admin@example.com"
-                 :password "admin-password"})
+(def admin-user {:username "admin-da-massa"
+                 :email    "admin-da-massa@example.com"
+                 :password "admin-da-massa-password"})
 
 (def user-auth (dissoc user :email))
 

--- a/test/integration/integration/components_test.clj
+++ b/test/integration/integration/components_test.clj
@@ -1,14 +1,25 @@
 (ns integration.components-test
   (:require [clojure.test :refer :all]
+            [matcher-combinators.test :refer [match?]]
             [com.stuartsierra.component :as component]
-            [porteiro.components :as components])
+            [common-clj.component.helper.core :as component.helper]
+            [porteiro.components :as components]
+            [porteiro.db.datomic.user :as database.user])
   (:import (com.stuartsierra.component SystemMap)))
 
 (deftest start-system!-test
-  (let [system (component/start components/system-test)]
+  (let [system             (component/start components/system-test)
+        datomic-connection (-> (component.helper/get-component-content :datomic system) :connection)]
 
     (testing "that the client is able to verify if the server is up with a get request"
       (is (= SystemMap
              (type system))))
+
+    (testing "that the default admin user was created"
+      (is (match? {:user/hashed-password string?
+                   :user/id              uuid?
+                   :user/roles           [:admin]
+                   :user/username        string?}
+                  (database.user/by-username "admin" datomic-connection))))
 
     (component/stop system)))


### PR DESCRIPTION
Now you can set an admin user from the config file. The admin user will be created on the first time the system is started (empty database).
