### PR TITLE
better sepation of auth controller responsability

### DIFF
--- a/src/porteiro/adapters/auth.clj
+++ b/src/porteiro/adapters/auth.clj
@@ -1,9 +1,14 @@
 (ns porteiro.adapters.auth
   (:require [schema.core :as s]
             [porteiro.wire.in.auth :as wire.in.auth]
+            [porteiro.wire.out.auth :as wire.out.auth]
             [porteiro.models.auth :as models.auth]))
 
 (s/defn wire->internal-user-auth :- models.auth/UserAuth
   [{:keys [username password]} :- wire.in.auth/UserAuth]
   {:user-auth/username username
    :user-auth/password password})
+
+(s/defn token->wire :- wire.out.auth/Token
+  [token :- s/Str]
+  {:token token})

--- a/src/porteiro/controllers/auth.clj
+++ b/src/porteiro/controllers/auth.clj
@@ -22,7 +22,7 @@
             {:exp (-> (t/plus (t/now) (t/days 1))
                       c/to-timestamp)}))
 
-(s/defn user-authentication!
+(s/defn user-authentication! :- s/Str
   [{:user-auth/keys [username password]} :- models.auth/UserAuth
    {:keys [jwt-secret]}
    producer
@@ -31,7 +31,7 @@
         {:contact/keys [email] :as contact} (first (database.contact/by-user-id id datomic))]
     (if (and user (:valid (hashers/verify password hashed-password)))
       (do (diplomatic.producer/send-success-auth-notification! email producer)
-          {:token (->token user contact jwt-secret)})
+          (->token user contact jwt-secret))
       (common-error/http-friendly-exception 403
                                             "invalid-credentials"
                                             "Wrong username or/and password"

--- a/src/porteiro/diplomatic/http_server/auth.clj
+++ b/src/porteiro/diplomatic/http_server/auth.clj
@@ -7,7 +7,8 @@
   [{auth                              :json-params
     {:keys [datomic producer config]} :components}]
   {:status 200
-   :body   (controllers.auth/user-authentication! (adapters.auth/wire->internal-user-auth auth)
-                                                  config
-                                                  producer
-                                                  (:connection datomic))})
+   :body   (-> (controllers.auth/user-authentication! (adapters.auth/wire->internal-user-auth auth)
+                                                      config
+                                                      producer
+                                                      (:connection datomic))
+               adapters.auth/token->wire)})

--- a/src/porteiro/wire/out/auth.clj
+++ b/src/porteiro/wire/out/auth.clj
@@ -1,0 +1,5 @@
+(ns porteiro.wire.out.auth
+  (:require [schema.core :as s]))
+
+(s/defschema Token
+  {:token s/Str})

--- a/test/unit/porteiro/adapters/auth_test.clj
+++ b/test/unit/porteiro/adapters/auth_test.clj
@@ -14,3 +14,8 @@
   (testing "that a invalid input will throws a exception"
     (is (thrown? ExceptionInfo (adapters.auth/wire->internal-user-auth {:username "ednaldo-pereira"
                                                                         :name     "Ednaldo Pereira"})))))
+
+(s/deftest token->wire-test
+  (testing "that we can externalize token value to wire out"
+    (is (= {:token "random-token"}
+           (adapters.auth/token->wire "random-token")))))


### PR DESCRIPTION
## Description
Better separation of auth controller responsability, moving wire out map assembly to an adapter fn.

## How Has This Been Tested?
We added a unit test for the adapters.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
