### PR TITLE
Rename diplomatic namespace to diplomat

### DIFF
--- a/src/porteiro/admin.clj
+++ b/src/porteiro/admin.clj
@@ -1,6 +1,6 @@
 (ns porteiro.admin
   (:require [com.stuartsierra.component :as component]
-            [porteiro.diplomatic.http-server.user :as diplomatic.http-server.user]
+            [porteiro.diplomat.http-server.user :as diplomat.http-server.user]
             [medley.core :as medley]
             [porteiro.db.datomic.user :as database.user]))
 
@@ -13,12 +13,12 @@
                                         :config config-content)]
 
       (when-not (database.user/by-username (:username admin-user-seed) (-> components :datomic :connection))
-        (let [wire-user-id (-> (diplomatic.http-server.user/create-user! {:json-params admin-user-seed
-                                                                          :components  components})
+        (let [wire-user-id (-> (diplomat.http-server.user/create-user! {:json-params  admin-user-seed
+                                                                          :components components})
                                :body :user :id)]
-          (diplomatic.http-server.user/add-role! {:query-params {:user-id wire-user-id
-                                                                 :role    "ADMIN"}
-                                                  :components   components})))))
+          (diplomat.http-server.user/add-role! {:query-params {:user-id wire-user-id
+                                                                 :role  "ADMIN"}
+                                                  :components components})))))
 
   (stop [component]))
 

--- a/src/porteiro/components.clj
+++ b/src/porteiro/components.clj
@@ -7,17 +7,17 @@
             [common-clj.component.service :as component.service]
             [common-clj.component.routes :as component.routes]
             [porteiro.admin :as admin]
-            [porteiro.diplomatic.http-server :as diplomatic.http-server]
-            [porteiro.diplomatic.consumer :as diplomatic.consumer]
+            [porteiro.diplomat.http-server :as diplomat.http-server]
+            [porteiro.diplomat.consumer :as diplomat.consumer]
             [porteiro.db.datomic.config :as database.config]))
 
 (def system
   (component/system-map
     :config (component.config/new-config "resources/config.edn" :prod :edn)
     :datomic (component/using (component.datomic/new-datomic database.config/schemas) [:config])
-    :consumer (component/using (component.consumer/new-consumer diplomatic.consumer/topic-consumers) [:config :datomic])
+    :consumer (component/using (component.consumer/new-consumer diplomat.consumer/topic-consumers) [:config :datomic])
     :producer (component/using (component.producer/new-producer) [:config])
-    :routes (component/using (component.routes/new-routes diplomatic.http-server/routes) [:datomic :config])
+    :routes (component/using (component.routes/new-routes diplomat.http-server/routes) [:datomic :config])
     :admin (component/using (admin/new-admin) [:datomic :config])
     :service (component/using (component.service/new-service) [:routes :config :datomic :producer])))
 
@@ -28,8 +28,8 @@
   (component/system-map
     :config (component.config/new-config "resources/config.example.edn" :test :edn)
     :datomic (component/using (component.datomic/new-datomic database.config/schemas) [:config])
-    :consumer (component/using (component.consumer/new-mock-consumer diplomatic.consumer/topic-consumers) [:config :datomic])
+    :consumer (component/using (component.consumer/new-mock-consumer diplomat.consumer/topic-consumers) [:config :datomic])
     :producer (component/using (component.producer/new-mock-producer) [:consumer :config])
-    :routes (component/using (component.routes/new-routes diplomatic.http-server/routes) [:datomic :config])
+    :routes (component/using (component.routes/new-routes diplomat.http-server/routes) [:datomic :config])
     :admin (component/using (admin/new-admin) [:datomic :config])
     :service (component/using (component.service/new-service) [:routes :config :datomic :producer])))

--- a/src/porteiro/controllers/auth.clj
+++ b/src/porteiro/controllers/auth.clj
@@ -11,7 +11,7 @@
             [porteiro.adapters.user :as adapters.user]
             [porteiro.db.datomic.contact :as database.contact]
             [porteiro.db.datomic.user :as datomic.user]
-            [porteiro.diplomatic.producer :as diplomatic.producer]))
+            [porteiro.diplomat.producer :as diplomat.producer]))
 
 (s/defn ^:private ->token :- s/Str
   [user :- models.user/User
@@ -30,7 +30,7 @@
   (let [{:user/keys [hashed-password id] :as user} (datomic.user/by-username username datomic)
         {:contact/keys [email] :as contact} (first (database.contact/by-user-id id datomic))]
     (if (and user (:valid (hashers/verify password hashed-password)))
-      (do (diplomatic.producer/send-success-auth-notification! email producer)
+      (do (diplomat.producer/send-success-auth-notification! email producer)
           (->token user contact jwt-secret))
       (common-error/http-friendly-exception 403
                                             "invalid-credentials"

--- a/src/porteiro/controllers/user.clj
+++ b/src/porteiro/controllers/user.clj
@@ -8,7 +8,7 @@
             [porteiro.models.contact :as models.contact]
             [porteiro.db.datomic.password-reset :as datomic.password-reset]
             [porteiro.db.datomic.contact :as database.contact]
-            [porteiro.diplomatic.producer :as diplomatic.producer]
+            [porteiro.diplomat.producer :as diplomat.producer]
             [porteiro.db.datomic.user :as database.user]
             [common-clj.error.core :as common-error]))
 
@@ -45,7 +45,7 @@
     (when user
       (some-> (datomic.password-reset/insert! password-reset datomic)
               :password-reset/id
-              (diplomatic.producer/send-password-reset-notification! (:contact/email contact) producer)))))
+              (diplomat.producer/send-password-reset-notification! (:contact/email contact) producer)))))
 
 (s/defn add-role! :- models.user/User
   [user-id :- s/Uuid

--- a/src/porteiro/diplomat/consumer.clj
+++ b/src/porteiro/diplomat/consumer.clj
@@ -1,4 +1,4 @@
-(ns porteiro.diplomatic.consumer
+(ns porteiro.diplomat.consumer
   (:require [schema.core :as s]
             [porteiro.adapters.contact :as adapters.contact]
             [porteiro.db.datomic.contact :as datomic.contact]

--- a/src/porteiro/diplomat/http_server.clj
+++ b/src/porteiro/diplomat/http_server.clj
@@ -1,42 +1,42 @@
-(ns porteiro.diplomatic.http-server
+(ns porteiro.diplomat.http-server
   (:require [porteiro.interceptors.user :as interceptors.user]
             [common-clj.io.interceptors :as io.interceptors]
             [porteiro.interceptors.password-reset :as interceptors.password-reset]
             [porteiro.interceptors.user-identity :as interceptors.user-identity]
-            [porteiro.diplomatic.http-server.healthy :as diplomatic.http-server.healthy]
-            [porteiro.diplomatic.http-server.password :as diplomatic.http-server.password]
-            [porteiro.diplomatic.http-server.user :as diplomatic.http-server.user]
-            [porteiro.diplomatic.http-server.auth :as diplomatic.http-server.auth]
-            [porteiro.diplomatic.http-server.contact :as diplomatic.http-server.contact]
+            [porteiro.diplomat.http-server.healthy :as diplomat.http-server.healthy]
+            [porteiro.diplomat.http-server.password :as diplomat.http-server.password]
+            [porteiro.diplomat.http-server.user :as diplomat.http-server.user]
+            [porteiro.diplomat.http-server.auth :as diplomat.http-server.auth]
+            [porteiro.diplomat.http-server.contact :as diplomat.http-server.contact]
             [porteiro.wire.in.user :as wire.in.user]
             [porteiro.wire.in.auth :as wire.in.auth]
             [porteiro.wire.in.password-reset :as wire.in.password-reset]))
 
 
-(def routes [["/health" :get diplomatic.http-server.healthy/healthy-check :route-name :health-check]
+(def routes [["/health" :get diplomat.http-server.healthy/healthy-check :route-name :health-check]
 
              ["/users" :post [(io.interceptors/schema-body-in-interceptor wire.in.user/User)
                               interceptors.user/username-already-in-use-interceptor
                               interceptors.user/email-already-in-use-interceptor
-                              diplomatic.http-server.user/create-user!] :route-name :create-user]
+                              diplomat.http-server.user/create-user!] :route-name :create-user]
 
              ["/users/contacts" :get [interceptors.user-identity/user-identity-interceptor
-                                      diplomatic.http-server.contact/fetch-contacts] :route-name :fetch-contacts]
+                                      diplomat.http-server.contact/fetch-contacts] :route-name :fetch-contacts]
 
              ["/users/auth" :post [(io.interceptors/schema-body-in-interceptor wire.in.auth/UserAuth)
-                                   diplomatic.http-server.auth/authenticate-user!] :route-name :user-authentication]
+                                   diplomat.http-server.auth/authenticate-user!] :route-name :user-authentication]
 
              ["/users/password" :put [(io.interceptors/schema-body-in-interceptor wire.in.user/PasswordUpdate)
                                       interceptors.user-identity/user-identity-interceptor
-                                      diplomatic.http-server.password/update-password!] :route-name :password-update]
+                                      diplomat.http-server.password/update-password!] :route-name :password-update]
 
              ["/users/request-password-reset" :post [(io.interceptors/schema-body-in-interceptor wire.in.user/PasswordReset)
-                                                     diplomatic.http-server.password/request-reset-password!] :route-name :request-password-reset]
+                                                     diplomat.http-server.password/request-reset-password!] :route-name :request-password-reset]
 
              ["/users/password-reset" :post [(io.interceptors/schema-body-in-interceptor wire.in.password-reset/PasswordResetExecution)
                                              interceptors.password-reset/valid-password-reset-execution-token
-                                             diplomatic.http-server.password/reset-password!] :route-name :password-reset]
+                                             diplomat.http-server.password/reset-password!] :route-name :password-reset]
 
              ["/users/roles" :post [interceptors.user-identity/user-identity-interceptor
                                     (interceptors.user-identity/user-required-roles-interceptor [:admin])
-                                    diplomatic.http-server.user/add-role!] :route-name :add-role-to-user]])
+                                    diplomat.http-server.user/add-role!] :route-name :add-role-to-user]])

--- a/src/porteiro/diplomat/http_server/auth.clj
+++ b/src/porteiro/diplomat/http_server/auth.clj
@@ -1,4 +1,4 @@
-(ns porteiro.diplomatic.http-server.auth
+(ns porteiro.diplomat.http-server.auth
   (:require [schema.core :as s]
             [porteiro.adapters.auth :as adapters.auth]
             [porteiro.controllers.auth :as controllers.auth]))

--- a/src/porteiro/diplomat/http_server/contact.clj
+++ b/src/porteiro/diplomat/http_server/contact.clj
@@ -1,4 +1,4 @@
-(ns porteiro.diplomatic.http-server.contact
+(ns porteiro.diplomat.http-server.contact
   (:require [schema.core :as s]
             [porteiro.controllers.contact :as controllers.contact]))
 

--- a/src/porteiro/diplomat/http_server/healthy.clj
+++ b/src/porteiro/diplomat/http_server/healthy.clj
@@ -1,4 +1,4 @@
-(ns porteiro.diplomatic.http-server.healthy
+(ns porteiro.diplomat.http-server.healthy
   (:require [schema.core :as s]
             [porteiro.controllers.healthy :as controllers.healthy]
             [porteiro.adapters.healthy :as adapters.healthy]))

--- a/src/porteiro/diplomat/http_server/password.clj
+++ b/src/porteiro/diplomat/http_server/password.clj
@@ -1,4 +1,4 @@
-(ns porteiro.diplomatic.http-server.password
+(ns porteiro.diplomat.http-server.password
   (:require [schema.core :as s]
             [porteiro.controllers.password-reset :as controllers.password-reset]
             [porteiro.controllers.user :as controllers.user]

--- a/src/porteiro/diplomat/http_server/user.clj
+++ b/src/porteiro/diplomat/http_server/user.clj
@@ -1,4 +1,4 @@
-(ns porteiro.diplomatic.http-server.user
+(ns porteiro.diplomat.http-server.user
   (:require [schema.core :as s]
             [porteiro.controllers.user :as controllers.user]
             [porteiro.adapters.user :as adapters.user]

--- a/src/porteiro/diplomat/producer.clj
+++ b/src/porteiro/diplomat/producer.clj
@@ -1,4 +1,4 @@
-(ns porteiro.diplomatic.producer
+(ns porteiro.diplomat.producer
   (:require [schema.core :as s]
             [clostache.parser :as parser]
             [common-clj.component.kafka.producer :as kafka.producer]


### PR DESCRIPTION
Fix typo renaming diplomatic namespace to diplomat